### PR TITLE
Remove AUTHENTICATION_REQUIRED error code

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -1178,20 +1178,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
 
     Generic403:
       description: Client does not have sufficient permission

--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -343,11 +343,12 @@ components:
                       - UNAUTHENTICATED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+
     Generic403:
       description: Forbidden
       headers:

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -465,7 +465,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_subscriptions_retrieve__list_401.10_no_authorization_header
+  @connected_network_type_subscriptions_retrieve_list_401.10_no_authorization_header
   Scenario: No Authorization header
     Given the request header "Authorization" is removed
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -380,7 +380,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_creation_401.2_expired_access_token
@@ -391,7 +391,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_creation_401.3_malformed_access_token
@@ -402,7 +402,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_401.4_no_authorization_header
@@ -412,7 +412,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_401.5_expired_access_token
@@ -422,7 +422,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_401.6_malformed_access_token
@@ -432,7 +432,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_delete_401.7_no_authorization_header
@@ -442,7 +442,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_delete_401.8_expired_access_token
@@ -452,7 +452,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_delete_401.9_malformed_access_token
@@ -462,7 +462,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve__list_401.10_no_authorization_header
@@ -472,7 +472,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_list_401.11_expired_access_token
@@ -482,7 +482,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_subscriptions_retrieve_list_401.12_malformed_access_token
@@ -492,7 +492,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, v0.1.0 - Operations cr
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
 ##################

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -157,7 +157,7 @@ Feature: CAMARA Connected Network Type API, v0.1.0 - Operation getConnectedNetwo
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_401.2_no_authorization_header
@@ -167,7 +167,7 @@ Feature: CAMARA Connected Network Type API, v0.1.0 - Operation getConnectedNetwo
     When the request "getConnectedNetworkType" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
   @connected_network_type_401.3_malformed_access_token
@@ -178,7 +178,7 @@ Feature: CAMARA Connected Network Type API, v0.1.0 - Operation getConnectedNetwo
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED" or "AUTHENTICATION_REQUIRED"
+    And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
 #################


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities pre-release [r3.1](https://github.com/camaraproject/Commonalities/releases/tag/r3.1) removes the `AUTHENTICATION_REQUIRED` error code, leaving `UNAUTHENTICATED` as the only valid error code when the HTTP status code is 401.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #6 
Fixes #7 

#### Special notes for reviewers:
This is not a breaking change

Issue #7 only required a 401 test case naming correction for these APIs

#### Changelog input
```
 release-note
 - Remove AUTHENTICATION_REQUIRED error code
```

#### Additional documentation 
None