### PR TITLE
Make lastStatusTime mandatory in 200 responses of the API

### DIFF
--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -22,8 +22,7 @@ info:
       - `5G`, if device is connected to the 5G network technology
       - `UNKNOWN` if connection [technology] can not be determined
 
-
-    * **LastStatusTime** : This property specifies the time when the status was last updated. Its presence in the response indicates the freshness of the information, while its absence implies the information may be outdated or its freshness is uncertain.
+    * **LastStatusTime** : This property specifies the time when the status was last confirmed to be correct. An older status is more likely to now be incorrect.
 
     # API Functionality
 
@@ -173,6 +172,7 @@ components:
     ConnectedNetworkTypeResponse:
       type: object
       required:
+        - lastStatusTime
         - connectedNetworkType
       properties:
         lastStatusTime:

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -34,7 +34,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetwork
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ConnectedNetworkTypeResponse"
     And the response property "$.connectedNetworkType" is "2G" or "3G" or "4G" or "5G"
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
 
   @connected_network_type_02_retrieval_undetermined_network
   Scenario: The connected network type of the user device can not be determined
@@ -47,7 +47,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetwork
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ConnectedNetworkTypeResponse"
     And the response property "$.connectedNetworkType" is "UNKNOWN"
-    And if the response property "$.lastStatusTime" is present, then the value has a valid date-time format
+    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
 
 #################
 # Error scenarios for management of input parameter device


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
This PR makes property `lastStatusTime` mandatory in 200 responses of the API

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #10 

#### Special notes for reviewers:
This is not a breaking change for the client

#### Changelog input
```
 release-note
 - Make lastStatusTime mandatory in 200 responses of the API
```

#### Additional documentation 
None