### PR TITLE
Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -12,7 +12,10 @@ info:
     # Relevant terms and definitions
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
-      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier (not supported for this API version) assigned by the mobile network operator for the device.
+
+        At least one identifier for the device out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Connected Network Type**: This Type identifies the mobile technology of the network that the device is connected to (e.g. 4G, 5G, etc). It is the same as what is displayed on the device (e.g. on mobile phones). When the device moves across different areas of the network, the technology may change. As each technology is different, network capabilities may differ and MUST be checked with the API provider.
        - `2G`: if device is connected to the 2G network technology (alternative indicators such as "G" or "E" may be displayed on the device)
@@ -20,6 +23,7 @@ info:
        - `4G`: if device is connected to the 4G network technology (alternative indicators such as "LTE" or "LTE+" may be displayed on the device)
        - `5G`: if device is connected to the 5G network technology
        - `UNKNOWN`: if connection [technology] can not be determined
+
     # API Functionality
 
     The API exposes following capabilities:
@@ -196,8 +200,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
               examples:
-                subscription-active:
-                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVE"
+                Active Subscription:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION"
+                Active Subscription With Device Disambiguation:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION"
         "202":
           description: Request accepted to be processed. It applies for async creation process.
           headers:
@@ -244,6 +250,11 @@ paths:
                 minItems: 0
                 items:
                   $ref: '#/components/schemas/Subscription'
+              examples:
+                List of Subscriptions:
+                  $ref: "#/components/examples/SUBSCRIPTION_LIST"
+                Empty List of Subscriptions:
+                  $ref: "#/components/examples/EMPTY_SUBSCRIPTION_LIST"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -274,8 +285,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
               examples:
-                Subscription Details:
-                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVE"
+                Active Subscription:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION"
+                Active Subscription With Device Disambiguation:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION"
+                Subscription Activation Requested:
+                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVATION_REQUESTED"
+                Subscription Deleted:
+                  $ref: "#/components/examples/SUBSCRIPTION_DELETED"
         "400":
           $ref: "#/components/responses/SubscriptionIdRequired400"
         "401":
@@ -720,6 +737,16 @@ components:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
 
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
+
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       type: string
@@ -850,7 +877,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         connectedNetworkType:
           $ref: "#/components/schemas/ConnectedNetworkType"
         subscriptionId:
@@ -873,7 +900,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         terminationReason:
           $ref: "#/components/schemas/TerminationReason"
         subscriptionId:
@@ -1160,6 +1187,7 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: "Expected property is missing: subscriptionId"
+
     Generic401:
       description: Authentication problem with the client request
       headers:
@@ -1347,18 +1375,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:
@@ -1448,7 +1469,55 @@ components:
           terminationDescription: Subscription expiry time has been reached
         time: "2024-03-05T15:00:23.682Z"
 
-    SUBSCRIPTION_ACTIVE:
+    SUBSCRIPTION_ACTIVATION_REQUESTED:
+      value:
+        id: 550e8400-e29b-41d4-a716-446655440000
+        sink: https://endpoint.example.com/sink
+        protocol: HTTP
+        types:
+          - "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
+        config:
+          subscriptionDetail: {}
+          subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        startsAt: "2024-07-03T21:12:02.871Z"
+        expiresAt: "2024-07-03T21:12:02.871Z"
+        status: ACTIVATION_REQUESTED
+
+    SUBSCRIPTION_DELETED:
+      value:
+        id: 550e8400-e29b-41d4-a716-446655440000
+        sink: https://endpoint.example.com/sink
+        protocol: HTTP
+        types:
+          - "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
+        config:
+          subscriptionDetail: {}
+          subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        startsAt: "2024-07-03T21:12:02.871Z"
+        expiresAt: "2024-07-03T21:12:02.871Z"
+        status: DELETED
+
+    ACTIVE_SUBSCRIPTION:
+      value:
+        id: 550e8400-e29b-41d4-a716-446655440000
+        sink: https://endpoint.example.com/sink
+        protocol: HTTP
+        types:
+          - "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
+        config:
+          subscriptionDetail: {}
+          subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        status: ACTIVE
+        startsAt: "2024-07-03T21:12:02.871Z"
+        expiresAt: "2024-07-03T21:12:02.871Z"
+
+    ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION:
       value:
         id: 550e8400-e29b-41d4-a716-446655440000
         sink: https://endpoint.example.com/sink
@@ -1462,9 +1531,10 @@ components:
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
           initialEvent: true
+        status: ACTIVE
         startsAt: "2024-07-03T21:12:02.871Z"
         expiresAt: "2024-07-03T21:12:02.871Z"
-        status: ACTIVE
+
     CREATE_SUBSCRIPTION:
       value:
         sink: "https://endpoint.example.com/sink"
@@ -1488,3 +1558,24 @@ components:
           "subscriptionMaxEvents": 5,
           "initialEvent": true
         }
+
+    SUBSCRIPTION_LIST:
+      description: A list of API consumer subscriptions. If a 3-legged access token is used, the list is specific to the device associated with that token.
+      value:
+        - id: 550e8400-e29b-41d4-a716-446655440000
+          sink: https://endpoint.example.com/sink
+          protocol: HTTP
+          types:
+            - "org.camaraproject.connected-network-type-subscriptions.v0.network-type-changed"
+          config:
+            subscriptionDetail: {}
+            subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
+            subscriptionMaxEvents: 5
+            initialEvent: true
+          startsAt: "2024-07-03T21:12:02.871Z"
+          expiresAt: "2024-07-03T21:12:02.871Z"
+          status: ACTIVE
+
+    EMPTY_SUBSCRIPTION_LIST:
+      description: The API consumer either has no subscriptions or, if a 3-legged access token is used, has none for the device associated with that token.
+      value: []

--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -13,7 +13,10 @@ info:
     # Relevant terms and definitions
 
     * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
-      At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device.
+
+        At least one identifier for the device (user equipment) out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     * **Connected Network Type** : This Type identifies the mobile technology of the network that the device is connected to (e.g. 4G, 5G, etc). It is the same as what is displayed on the device (e.g. on mobile phones). When the device moves across different areas of the network, the technology may change. As each technology is different, network capabilities may differ and MUST be checked with the API provider.
       - `2G`, if device is connected to the 2G network technology (alternative indicators such as "G" or "E" may be displayed on the device)
@@ -117,15 +120,22 @@ paths:
               schema:
                 $ref: "#/components/schemas/ConnectedNetworkTypeResponse"
               examples:
-                Connected-to-4G:
+                Connected To 4G:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectedNetworkType: 4G
-                Connected-to-5G:
+                Connected To 4G With Device Disambiguation:
+                  value:
+                    device:
+                      phoneNumber: "+123456789"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
+                    connectedNetworkType: 4G
+                Connected To 5G:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectedNetworkType: 5G
-                Connected-to-Undetermined:
+                Connectivity Unknown:
+                  description: Device is not connected to its home mobile network. It may be connected to a different network (e.g. roaming or a WiFi network) or not connected at all.
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectedNetworkType: UNKNOWN
@@ -175,6 +185,8 @@ components:
         - lastStatusTime
         - connectedNetworkType
       properties:
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
         lastStatusTime:
           $ref: "#/components/schemas/LastStatusTime"
         connectedNetworkType:
@@ -219,6 +231,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
@@ -323,6 +345,7 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
+
     Generic401:
       description: Unauthorized
       headers:
@@ -374,6 +397,7 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
+
     Generic404:
       description: Not found
       headers:
@@ -406,6 +430,7 @@ components:
                 status: 404
                 code: IDENTIFIER_NOT_FOUND
                 message: The phone number provided is not associated with a customer account
+
     Generic422:
       description: Unprocessable Content
       headers:
@@ -423,18 +448,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
                       - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:
@@ -459,6 +477,7 @@ components:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
+
     Generic429:
       description: Too Many Requests
       headers:

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -290,19 +290,6 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @connected_network_type_subscriptions_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "createConnectedNetworkTypeSubscription" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 ##################
 # Error code 400
 ##################

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -133,19 +133,6 @@ Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetwork
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @connected_network_type_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "getConnectedNetworkType" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 #################
 # Error code 401
 #################


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities has removed the `IDENTIFIER_MISMATCH` error for Fall25. Instead, a device identifier should not normally be included in responses. It should only be included to disambiguate the identity of the device when:
- the endpoint is being accessed using a 2-legged access token; and
- the endpoint allows for a device identifier to be provided in the request; and
- the API consumer has included multiple device identifiers

The response then includes the device identifier that was used by the implementation

This PR:
- Updates documentation in each OAS
- Adds relevant examples both for when device disambiguation is required, and when it is not required
- Uses `DeviceResponse` object for the connected-network-status API and for events in the connected-network-status-subscriptions API to limit device identifiers in responses to exactly one when used
- Removes the IDENTIFIER_MISMATCH error code option from 422 responses

Note; For subscriptions, the `CreateSubscriptionDetail` schema is used in both requests and responses, so modifying the responses to use the `DeviceResponse` would require a general update of the subscription schema in Commonalities. For the moment, the existing schema is left unmodified, which means that multiple device identifiers could be provided in responses, but should not.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #20 

#### Special notes for reviewers:
I think both GET endpoints should never return a device identifier in the responses, but haven't thought through all possible scenarios, so will raise this as a separate issue.

#### Changelog input

```
 release-note
 - Update documentation in each OAS
 - Add relevant examples both for when device disambiguation is required, and when it is not required
-  Use `DeviceResponse` object for the connected-network-status API and for events in the connected-network-status-subscriptions API to limit device identifiers in responses to exactly one when used
- Remove the IDENTIFIER_MISMATCH error code option from 422 responses
```

#### Additional documentation 
None