### PR TITLE
Commonalities alignement for connected network type subscription & connected network type

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -410,6 +410,7 @@ components:
         sink:
           type: string
           format: uri
+          pattern: ^https:\/\/.+$
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
@@ -632,6 +633,7 @@ components:
         sink:
           type: string
           format: uri
+          pattern: ^https:\/\/.+$
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         types:
@@ -707,6 +709,8 @@ components:
     SubscriptionAsync:
       description: Response for a event-type subscription request managed asynchronously (Creation or Deletion)
       type: object
+      required:
+        - id
       properties:
         id:
           $ref: "#/components/schemas/SubscriptionId"
@@ -1106,6 +1110,7 @@ components:
                       - INVALID_PROTOCOL
                       - INVALID_CREDENTIAL
                       - INVALID_TOKEN
+                      - INVALID_SINK
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -1137,6 +1142,12 @@ components:
                 status: 400
                 code: INVALID_TOKEN
                 message: Only bearer token is supported
+            GENERIC_400_INVALID_SINK:
+              description: Invalid sink value
+              value:
+                status: 400
+                code: INVALID_SINK
+                message: sink not valid for the specified protocol
 
     Generic400:
       description: Problem with the client request

--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -129,7 +129,7 @@ paths:
               examples:
                 Connected To 4G:
                   value:
-                    : "2024-02-20T10:41:38.657Z"
+                    lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectedNetworkType: 4G
                 Connected To 4G With Device Disambiguation:
                   value:

--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -129,7 +129,7 @@ paths:
               examples:
                 Connected To 4G:
                   value:
-                    lastStatusTime: "2024-02-20T10:41:38.657Z"
+                    : "2024-02-20T10:41:38.657Z"
                     connectedNetworkType: 4G
                 Connected To 4G With Device Disambiguation:
                   value:
@@ -180,7 +180,10 @@ components:
 
   schemas:
     LastStatusTime:
-      description: Last time that the associated connected Network Type was updated
+      description: |
+        Last time that the associated device reachability status was updated.
+        It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+        Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
       type: string
       format: date-time
       example: "2024-02-20T10:41:38.657Z"

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -355,6 +355,16 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operations crea
     And the response property "$.code" is "INVALID_TOKEN"
     And the response property "$.message" contains a user friendly text
 
+  @connected_network_type_subscriptions_400.7_create_subscription_with_invalid_sink_url
+  Scenario: Subscription creation with invalid url
+    Given the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
+    And the request property "$.protocol" is set to "HTTP"
+    And the request property "$.sink" is set to "azerty"
+    When the request "createConnectedNetworkTypeSubscription" is sent
+    Then the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_SINK"
+    And the response property "$.message" contains a user friendly text
+
 ##################
 # Error code 401
 ##################


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Following ajustement:

- Improve sink attribute management (add pattern & 400 error)
- add (subscription)id as mandatory in SubscriptionAsync schema
- add missing RFC3339 format description in LastStatusTime attribute


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #33 

#### Special notes for reviewers:



#### Changelog input

```
release-note
- add pattern for sink 
- add error 400 INVALID_SINK in the yaml
- add test case for 400 INVALID_SINK
- make subscription id mandatory in async subscription response
- add missing RFC3339 format description for LastStatusTime

```

#### Additional documentation 

This section can be blank.



```
docs

```
