### PR TITLE
Release r1.2 (Fall'25 M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog ConnectedNetworkType
 ## Table of Contents
+- **[r1.2](#r12)**
 - [r1.1](#r11)
 
 **Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
@@ -12,6 +13,70 @@ The below sections record the changes for each API version in each release as fo
   - for a public release, the consolidated changes since the previous public release
 
 Note: this API had former releases in the [DeviceStatus](https://github.com/camaraproject/DeviceStatus) repository
+
+# r1.2
+## Release Notes
+
+This public release contains the definition and documentation of
+* connected-network-type v0.2.0
+* connected-network-type-subscriptions v0.2.0
+
+The API definition(s) are based on
+* Commonalities v0.6.0 (r3.3)
+* Identity and Consent Management v0.4.0 (r3.3)
+
+## connected-network-type v0.2.0
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/ConnectedNetworkType/blob/r1.2/code/API_definitions/connected-network-type.yaml)
+
+### Added
+
+### Changed
+* Make lastStatusTime mandatory in 200 responses of the API by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/17
+* Update x-correlator schema by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/26
+* Update error response documentation in OAS definitions by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/27
+* Commonalities alignement for connected network type subscription & connected network type by @bigludo7 in https://github.com/camaraproject/ConnectedNetworkType/pull/34
+* Fix feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/38
+* Further fix for feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/40
+* Migrate to centralized linting workflows by @hdamker-bot in https://github.com/camaraproject/ConnectedNetworkType/pull/37
+
+### Fixed
+
+### Removed
+* Remove AUTHENTICATION_REQUIRED error code by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/12
+* Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/24
+
+## connected-network-type-subscriptions v0.2.0
+
+- API definition **with inline documentation**:
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/ConnectedNetworkType/blob/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml)
+
+### Added
+* Add subscription started & updated events by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/31
+
+### Changed
+* change sink format to format: uri by @maxl2287 in https://github.com/camaraproject/ConnectedNetworkType/pull/16
+* Update x-correlator schema by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/26
+* Rename subscription-ends event to subscription-ended by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/28
+* Update error response documentation in OAS definitions by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/27
+* Commonalities alignement for connected network type subscription & connected network type by @bigludo7 in https://github.com/camaraproject/ConnectedNetworkType/pull/34
+* Fix feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/38
+* Further fix for feature files for compliance with centralised linting rules by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/40
+* Migrate to centralized linting workflows by @hdamker-bot in https://github.com/camaraproject/ConnectedNetworkType/pull/37
+
+### Fixed
+* remove "Generic High Entropy Secret" by @maxl2287 in https://github.com/camaraproject/ConnectedNetworkType/pull/15
+
+### Removed
+* Remove AUTHENTICATION_REQUIRED error code by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/12
+* Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/24
+
+**Full Changelog**: https://github.com/camaraproject/ConnectedNetworkType/commits/r1.2
 
 # r1.1
 ## Release Notes
@@ -38,8 +103,8 @@ The API definition(s) are based on
 * Update x-correlator schema by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/26
 * Update error response documentation in OAS definitions by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/27
 * Commonalities alignement for connected network type subscription & connected network type by @bigludo7 in https://github.com/camaraproject/ConnectedNetworkType/pull/34
-### Fixed
 
+### Fixed
 
 ### Removed
 * Remove AUTHENTICATION_REQUIRED error code by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/12
@@ -70,4 +135,3 @@ The API definition(s) are based on
 * Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code by @eric-murray in https://github.com/camaraproject/ConnectedNetworkType/pull/24
 
 **Full Changelog**: https://github.com/camaraproject/ConnectedNetworkType/commits/r1.1
-

--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ Sandbox API Repository to describe, develop, document, and test the ConnectedNet
 
 ## Release Information
 
-The latest public release of the Device Status repository, including the ConnectedNetworkType API, is available here: https://github.com/camaraproject/DeviceStatus/releases/latest
-<!-- Optional: an explicit listing of the latest (pre-)release with additional information, e.g. links to the API definitions -->
-<!-- In addition use/uncomment one or multiple the following alternative options when becoming applicable -->
-Pre-releases of this sub project are available in https://github.com/camaraproject/ConnectedNetworkType/releases
-<!-- The latest public release is available here: https://github.com/camaraproject/ConnectedNetworkType/releases/latest -->
-<!-- For changes see [CHANGELOG.md](https://github.com/camaraproject/ConnectedNetworkType/blob/main/CHANGELOG.md) -->
+The latest public release of the ConnectedNetworkType repository is available [here](https://github.com/camaraproject/DeviceStatus/releases/latest)
+
+  * **connected-network-type v0.2.0**  
+  [[YAML]](https://github.com/camaraproject/ConnectedNetworkType/blob/r1.2/code/API_definitions/connected-network-type.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type.yaml)
+  * **connected-network-type-subscriptions v0.2.0**  
+  [[YAML]](https://github.com/camaraproject/ConnectedNetworkType/blob/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type-subscriptions&nocors)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml)
+
+Pre-releases of this sub project are available [here](https://github.com/camaraproject/ConnectedNetworkType/releases). For changes see the [change log](https://github.com/camaraproject/ConnectedNetworkType/blob/main/CHANGELOG.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The latest public release of the ConnectedNetworkType repository is available [h
 
   * **connected-network-type v0.2.0**  
   [[YAML]](https://github.com/camaraproject/ConnectedNetworkType/blob/r1.2/code/API_definitions/connected-network-type.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type&nocors)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type.yaml&nocors)
   [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type.yaml)
   * **connected-network-type-subscriptions v0.2.0**  
   [[YAML]](https://github.com/camaraproject/ConnectedNetworkType/blob/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml)
-  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type-subscriptions&nocors)
+  [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml&nocors)
   [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/ConnectedNetworkType/r1.2/code/API_definitions/connected-network-type-subscriptions.yaml)
 
 Pre-releases of this sub project are available [here](https://github.com/camaraproject/ConnectedNetworkType/releases). For changes see the [change log](https://github.com/camaraproject/ConnectedNetworkType/blob/main/CHANGELOG.md).

--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -116,14 +116,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 0.2.0
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/connected-network-type-subscriptions/vwip"
+  - url: "{apiRoot}/connected-network-type-subscriptions/v0.2"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -82,14 +82,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: wip
+  version: 0.2.0
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/DeviceStatus
 
 servers:
-  - url: "{apiRoot}/connected-network-type/vwip"
+  - url: "{apiRoot}/connected-network-type/v0.2"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -1,5 +1,5 @@
 # connected-network-type-subscriptions
-Feature: CAMARA Connected Network Type Subscriptions API, vwip
+Feature: CAMARA Connected Network Type Subscriptions API, v0.2.0
   # Operations createConnectedNetworkTypeSubscription, retrieveConnectedNetworkTypeSubscriptionList, retrieveConnectedNetworkTypeSubscription and deleteConnectedNetworkTypeSubscription
 
   # Input to be provided by the implementation to the tester
@@ -16,7 +16,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip
   # References to OAS spec schemas refer to schemas specifies in connected-network-type-subscriptions.yaml
 
   Background: Connected Network Type Subscriptions setup
-    Given the resource "{apiroot}/connected-network-type-subscriptions/vwip" as base-url
+    Given the resource "{apiroot}/connected-network-type-subscriptions/v0.2" as base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -1,5 +1,5 @@
 # connected-network-type
-Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetworkType
+Feature: CAMARA Connected Network Type API, v0.2.0 - Operation getConnectedNetworkType
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -13,7 +13,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetwork
   # References to OAS spec schemas refer to schemas specifies in connected-network-type.yaml
 
   Background: Common Connected Network Type setup
-    Given the resource "{api-root}/connected-network-type/vwip/retrieve" set as base-url
+    Given the resource "{api-root}/connected-network-type/v0.2/retrieve" set as base-url
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/documentation/API_documentation/connected-network-type-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/connected-network-type-API-Readiness-Checklist.md
@@ -1,12 +1,12 @@
 # API Readiness Checklist
 
-Checklist for connected-network-type 0.2.0-rc.1 in r1.1.
+Checklist for connected-network-type 0.2.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [/code/API_definitions/connected-network-type.yaml](/code/API_definitions/connected-network-type.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |   [r3.2](https://github.com/camaraproject/Commonalities/releases/tag/r3.2)   |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |   [r3.2](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2)   |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |   [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.3)   |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |   [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.3)   |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |  N    |      |

--- a/documentation/API_documentation/connected-network-type-subscriptions-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/connected-network-type-subscriptions-API-Readiness-Checklist.md
@@ -1,12 +1,12 @@
 # API Readiness Checklist
 
-Checklist for connected-network-type-subscriptions 0.2.0-rc.1 in r1.1.
+Checklist for connected-network-type-subscriptions 0.2.0 in r1.2
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----:|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |   Y   | [/code/API_definitions/connected-network-type-subscriptions.yaml](/code/API_definitions/connected-network-type-subscriptions.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/Commonalities/releases/tag/r3.2)    |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |  [r3.2](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2)    |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y   |  [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.3)    |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y   |  [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.3)    |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y   |      |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y   | inline in YAML |
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |  N    |      |


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
Publication of Fall'25 M4 public release of:
- connected-network-type v0.2.0
- connected-network-type-subscriptions v0.2.0

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #36 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Publication of Fall'25 M4 public release of connected-network-type v0.2.0 and connected-network-type-subscriptions v0.2.0
```

#### Additional documentation 
None