### PR TITLE
Append Local to overridden schema to avoid renaming warnings

### DIFF
--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -466,7 +466,7 @@ components:
           items:
             $ref: "#/components/schemas/ApiEventType"
         config:
-          $ref: "#/components/schemas/Config2"
+          $ref: "#/components/schemas/ConfigLocal"
         id:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
         startsAt:

--- a/code/API_definitions/connected-network-type-subscriptions.yaml
+++ b/code/API_definitions/connected-network-type-subscriptions.yaml
@@ -388,21 +388,21 @@ components:
         $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
 
   schemas:
-    CreateSubscriptionDetail:
+    CreateSubscriptionDetailLocal:
       description: The detail of the requested event subscription.
       type: object
       properties:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
 
-    Config2:
+    ConfigLocal:
       description: Config schema allowing for device to be specified as part of subscription detail
       allOf:
         - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
         - type: object
           properties:
             subscriptionDetail:
-              $ref: "#/components/schemas/CreateSubscriptionDetail"
+              $ref: "#/components/schemas/CreateSubscriptionDetailLocal"
 
     ApiEventType:
       type: string
@@ -540,7 +540,7 @@ components:
           items:
             $ref: "#/components/schemas/ApiEventType"
         config:
-          $ref: "#/components/schemas/Config2"
+          $ref: "#/components/schemas/ConfigLocal"
       discriminator:
         propertyName: protocol
         mapping:


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Release automation renames overridden common schema by appending `-2` to the local schema, which triggers a validation warning. This PR appends `Local` to the overridden schema to avoid this.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #66 

#### Special notes for reviewers:
Only schema renaming - no other changes.

#### Changelog input

```
 release-note
 - Append Local to overridden schema to avoid renaming warnings
```

#### Additional documentation 
None