### PR TITLE
Make lastStatusTime nullable, and add an example

### DIFF
--- a/code/API_definitions/connected-network-type.yaml
+++ b/code/API_definitions/connected-network-type.yaml
@@ -163,6 +163,10 @@ paths:
                   value:
                     lastStatusTime: "2024-02-20T10:41:38.657Z"
                     connectedNetworkType: UNKNOWN
+                Last Status Update Time Unknown:
+                  value:
+                    lastStatusTime: null
+                    connectedNetworkType: 4G
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -185,8 +189,11 @@ components:
       description: |
         The last time that the connected network type status was confirmed to be correct by the API provider. The status should still be valid, but the API provider is unable to confirm this.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-      allOf:
-        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+      type: string
+      format: date-time
+      maxLength: 64
+      nullable: true
+      example: "2018-04-05T17:31:00Z"
 
     ConnectedNetworkTypeResponse:
       description: Definition of the data that can be returned in the response body

--- a/code/Test_definitions/connected-network-type.feature
+++ b/code/Test_definitions/connected-network-type.feature
@@ -36,7 +36,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetwork
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ConnectedNetworkTypeResponse"
     And the response property "$.connectedNetworkType" is "2G" or "3G" or "4G" or "5G"
-    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
+    And the response property "$.lastStatusTime" is present and either has a valid date-time format for a time in the past, or is null
 
   @connected_network_type_02_retrieval_undetermined_network
   Scenario: The connected network type of the user device can not be determined
@@ -49,7 +49,7 @@ Feature: CAMARA Connected Network Type API, vwip - Operation getConnectedNetwork
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/ConnectedNetworkTypeResponse"
     And the response property "$.connectedNetworkType" is "UNKNOWN"
-    And the response property "$.lastStatusTime" is present and has a valid date-time format for a time in the past
+    And the response property "$.lastStatusTime" is present and either has a valid date-time format for a time in the past, or is null
 
 #################
 # Error scenarios for management of input parameter device


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Allow lastStatusTime to be nullable, so that null can be provided as a value when the implementation has no clue when the connected network type they provide was known to be correct. The API consumer must then decide for themselves whether the connected network type provided is of any value to them.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #60 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Make lastStatusTime nullable, and add an example
```

#### Additional documentation 
None