### PR TITLE
[Added] Move device connected network type subscription list scenarios to separate file and update

### DIFF
--- a/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
+++ b/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
@@ -1,6 +1,5 @@
 # connected-network-type-subscriptions
-Feature: CAMARA Connected Network Type Subscriptions API, vwip
-  # Operations retrieveConnectedNetworkTypeSubscriptionList
+Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operation retrieveConnectedNetworkTypeSubscriptionList
 
   # Input to be provided by the implementation to the tester
   #
@@ -26,48 +25,144 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip
 # Happy path scenarios
 ##########################
 
-  @connected_network_type_subscriptions_04_retrieve_list_2legs
-  Scenario: Check existing subscription(s) is/are retrieved in list using a 2-legged access token
-    Given at least one subscription is existing for the API consumer making this request
+  @connected_network_type_subscriptions_01_operation_to_retrieve_list_of_subscriptions_2legs
+  Scenario: Get a list of subscriptions for a 2-legged access token
+    Given an API consumer that has created at least one connected network type subscription
     And the header "Authorization" is set to a valid access token which does not identify any device
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 200
+    Then the response code is 200
     And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And the response body lists all subscriptions belonging to the API consumer
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And each item in the response body array "$.subscriptions" complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" includes all subscriptions created by the API consumer
+    And the response body array "$.subscriptions" does not include any subscriptions created by a different API consumer
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
 
-  @connected_network_type_subscriptions_05_retrieve_list_3legs
-  Scenario: Check existing subscription(s) is/are retrieved in list using a 3-legged access token
-    Given the API consumer has at least one active subscription for the device
-    And the header "Authorization" is set to a valid access token which identifies a valid device associated with one or more subscriptions
+  @connected_network_type_status_subscriptions_02_operation_to_retrieve_list_of_subscriptions_3legs
+  Scenario: Get a list of subscriptions for a 3-legged access token
+    Given an API consumer that has created at least one connected network type subscription for a given device
+    And the header "Authorization" is set to a valid access token which identifies that device
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 200
+    Then the response code is 200
     And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And the response body lists all subscriptions belonging to the API consumer for the identified device
-    And the response property "$.config.subscriptionDetail.device" is not present in any of the subscription records
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And each item in the response body array "$.subscriptions" complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" includes all subscriptions created by the API consumer for the identified device
+    And the response body array "$.subscriptions" does not include any subscriptions created by the API consumer for a different device
+    And the response body array "$.subscriptions" does not include any subscriptions created by a different API consumer
+    And the response property "$.subscriptions[*].config.subscriptionDetail.device" is not present for any of the subscription records
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
 
-  @connected_network_type_subscriptions_06_retrieve_empty_list_3legs
-  Scenario: Check no existing subscription is retrieved in list
-    Given the API consumer has no active subscriptions for the device
-    And the header "Authorization" is set to a valid access token which identifies a valid device
+  @connected_network_type_subscriptions_03_operation_to_retrieve_list_of_subscriptions_when_no_records
+  Scenario: Get a list of connected network type subscriptions when no subscriptions are available
+    Given an API consumer that has created no connected network type subscriptions
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 200
+    Then the response code is 200
     And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body is an empty array
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body array "$.subscriptions" is an empty array
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+
+  @connected_network_type_subscriptions_04_pagination_default_values
+  Scenario: Subscription list pagination with default values for page and perPage
+    Given an API consumer who has created more than 20 connected network type subscriptions
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent without setting query parameters "page" and "perPage"
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the next page with rel="next"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body property "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 1
+    And the response body property "$.pagination.perPage" is 20
+
+  @connected_network_type_subscriptions_05_pagination_custom_values
+  Scenario: Subscription list pagination with custom values for page and perPage
+    Given an API consumer who has created more than 40 connected network type subscriptions
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent with query parameters "page" set to 1 and "perPage" set to 20
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the next page with rel="next"
+    And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
+    And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body property "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 1
+    And the response body property "$.pagination.perPage" is 20
+    And the response body property "$.pagination.totalPages", if present, is greater than 2
+    And the response body property "$.pagination.totalCount", if present, is greater than 40
+
+  @connected_network_type_subscriptions_06_pagination_middle_page
+  Scenario: Subscription list pagination fetching a middle page of the list
+    Given an API consumer who has created more than 40 connected network type subscriptions
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent with query parameters "page" set to 2 and "perPage" set to 20
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the previous page with rel="prev" and a link to the next page with rel="next"
+    And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
+    And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body property "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 2
+    And the response body property "$.pagination.perPage" is 20
+    And the response body property "$.pagination.totalPages", if present, is greater than 2
+    And the response body property "$.pagination.totalCount", if present, is greater than 40
+
+  @connected_network_type_subscriptions_07_pagination_last_page
+  Scenario: Subscription list pagination fetching the last page of the list
+    Given an API consumer who has created more than 40 and less than 60 connected network type subscriptions
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent with query parameters "page" set to 3 and "perPage" set to 20
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the previous page with rel="prev"
+    And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
+    And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body property "$.subscriptions" has between 1 and 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 3
+    And the response body property "$.pagination.perPage" is 20
+    And the response body property "$.pagination.totalPages", if present, is 3
+    And the response body property "$.pagination.totalCount", if present, is greater than 40 and less than 60
 
 ##################
 # Error code 400
 ##################
 
+  @connected_network_type_subscriptions_retrieve_list_400.01_pagination_invalid_page_parameter
+  Scenario: Subscription list pagination with invalid value for page parameter
+    Given an API consumer who has created more than 20 connected network type subscriptions
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent with query parameter "page" set to any value less than 1 and "perPage" set to 20
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @connected_network_type_subscriptions_retrieve_list_400.02_pagination_invalid_perPage_parameter
+  Scenario: Subscription list pagination with invalid value for perPage parameter
+    Given an API consumer who has created more than 20 connected network type subscriptions
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent with query parameter "page" set to 1 and "perPage" set to any value outside the range [1-100]
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
 ##################
 # Error code 401
 ##################
 
-  @connected_network_type_subscriptions_retrieve_list_401.10_no_authorization_header
+  @connected_network_type_subscriptions_retrieve_list_401.01_no_authorization_header
   Scenario: No Authorization header when retrieving subscription list
     Given the request header "Authorization" is removed
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
@@ -77,7 +172,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_subscriptions_retrieve_list_401.11_expired_access_token
+  @connected_network_type_subscriptions_retrieve_list_401.02_expired_access_token
   Scenario: Expired access token when retrieving subscription list
     Given the header "Authorization" is set to a previously valid but now expired access token
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
@@ -87,7 +182,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @connected_network_type_subscriptions_retrieve_list_401.12_malformed_access_token
+  @connected_network_type_subscriptions_retrieve_list_401.03_malformed_access_token
   Scenario: Malformed access token when retrieving subscription list
     Given the header "Authorization" is set to a malformed token
     When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent

--- a/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
+++ b/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
@@ -1,0 +1,106 @@
+# connected-network-type-subscriptions
+Feature: CAMARA Connected Network Type Subscriptions API, vwip
+  # Operations createConnectedNetworkTypeSubscription, retrieveConnectedNetworkTypeSubscriptionList, retrieveConnectedNetworkTypeSubscription and deleteConnectedNetworkTypeSubscription
+
+  # Input to be provided by the implementation to the tester
+  #
+  # Implementation indications:
+  # * List of device identifier types which are not supported, among: phoneNumber, networkAccessIdentifier, ipv4Address, ipv6Address
+  #
+  # Testing assets:
+  # * A device object where the tester can select between multiple network types.
+  # * (optional: Additional devices object which supports 2G, 3G, 4G and/or 5G)
+  # * The known connected Generation of Mobile Communication Technology.
+  # * A sink-url identified as "callbackUrl", which receives notifications
+  # * apiRoot: API root of the server URL
+  #
+  # References to OAS spec schemas refer to schemas specifies in connected-network-type-subscriptions.yaml
+
+  Background: Connected Network Type Subscriptions setup
+    Given an environment at "apiRoot"
+    And the resource "/connected-network-type-subscriptions/vwip"
+    And the header "Authorization" is set to a valid access token
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+##########################
+# Happy path scenarios
+##########################
+
+  @connected_network_type_subscriptions_04_retrieve_list_2legs
+  Scenario: Check existing subscription(s) is/are retrieved in list using a 2-legged access token
+    Given at least one subscription is existing for the API consumer making this request
+    And the header "Authorization" is set to a valid access token which does not identify any device
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
+    And the response body lists all subscriptions belonging to the API consumer
+
+  @connected_network_type_subscriptions_05_retrieve_list_3legs
+  Scenario: Check existing subscription(s) is/are retrieved in list using a 3-legged access token
+    Given the API consumer has at least one active subscription for the device
+    And the header "Authorization" is set to a valid access token which identifies a valid device associated with one or more subscriptions
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
+    And the response body lists all subscriptions belonging to the API consumer for the identified device
+    And the response property "$.config.subscriptionDetail.device" is not present in any of the subscription records
+
+  @connected_network_type_subscriptions_06_retrieve_empty_list_3legs
+  Scenario: Check no existing subscription is retrieved in list
+    Given the API consumer has no active subscriptions for the device
+    And the header "Authorization" is set to a valid access token which identifies a valid device
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response body is an empty array
+
+##################
+# Error code 400
+##################
+
+##################
+# Error code 401
+##################
+
+  @connected_network_type_subscriptions_retrieve_list_401.10_no_authorization_header
+  Scenario: No Authorization header when retrieving subscription list
+    Given the request header "Authorization" is removed
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @connected_network_type_subscriptions_retrieve_list_401.11_expired_access_token
+  Scenario: Expired access token when retrieving subscription list
+    Given the header "Authorization" is set to a previously valid but now expired access token
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @connected_network_type_subscriptions_retrieve_list_401.12_malformed_access_token
+  Scenario: Malformed access token when retrieving subscription list
+    Given the header "Authorization" is set to a malformed token
+    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+##################
+# Error code 403
+##################
+
+##################
+# Error code 404
+##################

--- a/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
+++ b/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
@@ -1,4 +1,4 @@
-# connected-network-type-subscriptions
+# connected-network-type-subscriptions-retrieveConnectedNetworkTypeSubscriptionList
 Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operation retrieveConnectedNetworkTypeSubscriptionList
 
   # Input to be provided by the implementation to the tester
@@ -52,7 +52,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operation retri
     And the response body array "$.subscriptions" includes all subscriptions created by the API consumer for the identified device
     And the response body array "$.subscriptions" does not include any subscriptions created by the API consumer for a different device
     And the response body array "$.subscriptions" does not include any subscriptions created by a different API consumer
-    And the response property "$.subscriptions[*].config.subscriptionDetail.device" is not present for any of the subscription records
+    And the response body property "$.subscriptions[*].config.subscriptionDetail.device" is not present for any of the subscription records
     And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
 
   @connected_network_type_subscriptions_03_operation_to_retrieve_list_of_subscriptions_when_no_records
@@ -75,7 +75,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operation retri
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response header "Link" contains a link to the next page with rel="next"
     And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
-    And the response body property "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
     And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
     And the response body property "$.pagination.page" is 1
     And the response body property "$.pagination.perPage" is 20
@@ -91,7 +91,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operation retri
     And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
     And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
     And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
-    And the response body property "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
     And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
     And the response body property "$.pagination.page" is 1
     And the response body property "$.pagination.perPage" is 20
@@ -109,7 +109,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operation retri
     And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
     And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
     And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
-    And the response body property "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
     And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
     And the response body property "$.pagination.page" is 2
     And the response body property "$.pagination.perPage" is 20
@@ -127,7 +127,7 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip - Operation retri
     And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
     And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
     And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
-    And the response body property "$.subscriptions" has between 1 and 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" has between 1 and 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
     And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
     And the response body property "$.pagination.page" is 3
     And the response body property "$.pagination.perPage" is 20

--- a/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
+++ b/code/Test_definitions/connected-network-type-retrieveConnectedNetworkTypeSubscriptionList.feature
@@ -1,6 +1,6 @@
 # connected-network-type-subscriptions
 Feature: CAMARA Connected Network Type Subscriptions API, vwip
-  # Operations createConnectedNetworkTypeSubscription, retrieveConnectedNetworkTypeSubscriptionList, retrieveConnectedNetworkTypeSubscription and deleteConnectedNetworkTypeSubscription
+  # Operations retrieveConnectedNetworkTypeSubscriptionList
 
   # Input to be provided by the implementation to the tester
   #

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -1,6 +1,6 @@
 # connected-network-type-subscriptions
 Feature: CAMARA Connected Network Type Subscriptions API, vwip
-  # Operations createConnectedNetworkTypeSubscription, retrieveConnectedNetworkTypeSubscriptionList, retrieveConnectedNetworkTypeSubscription and deleteConnectedNetworkTypeSubscription
+  # Operations createConnectedNetworkTypeSubscription, retrieveConnectedNetworkTypeSubscription and deleteConnectedNetworkTypeSubscription
 
   # Input to be provided by the implementation to the tester
   #

--- a/code/Test_definitions/connected-network-type-subscriptions.feature
+++ b/code/Test_definitions/connected-network-type-subscriptions.feature
@@ -115,39 +115,6 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip
     And the response property "$.id" is equal to "id"
     And the response property "$.config.subscriptionDetail.device" is not present
 
-  @connected_network_type_subscriptions_04_retrieve_list_2legs
-  Scenario: Check existing subscription(s) is/are retrieved in list using a 2-legged access token
-    Given at least one subscription is existing for the API consumer making this request
-    And the header "Authorization" is set to a valid access token which does not identify any device
-    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And the response body lists all subscriptions belonging to the API consumer
-
-  @connected_network_type_subscriptions_05_retrieve_list_3legs
-  Scenario: Check existing subscription(s) is/are retrieved in list using a 3-legged access token
-    Given the API consumer has at least one active subscription for the device
-    And the header "Authorization" is set to a valid access token which identifies a valid device associated with one or more subscriptions
-    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And the response body lists all subscriptions belonging to the API consumer for the identified device
-    And the response property "$.config.subscriptionDetail.device" is not present in any of the subscription records
-
-  @connected_network_type_subscriptions_06_retrieve_empty_list_3legs
-  Scenario: Check no existing subscription is retrieved in list
-    Given the API consumer has no active subscriptions for the device
-    And the header "Authorization" is set to a valid access token which identifies a valid device
-    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body is an empty array
-
   @connected_network_type_subscriptions_07_delete_subscription_based_on_an_existing_subscription-id
   Scenario: Delete the subscription with subscriptionId equal to "id"
     Given the API consumer has an active subscription with "subscriptionId" equal to "id"
@@ -457,36 +424,6 @@ Feature: CAMARA Connected Network Type Subscriptions API, vwip
   Scenario: Malformed access token when deleting subscription
     Given the header "Authorization" is set to a malformed token
     When the request "deleteConnectedNetworkTypeSubscription" is sent
-    Then the response status code is 401
-    And the response header "Content-Type" is "application/json"
-    And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
-    And the response property "$.message" contains a user friendly text
-
-  @connected_network_type_subscriptions_retrieve_list_401.10_no_authorization_header
-  Scenario: No Authorization header when retrieving subscription list
-    Given the request header "Authorization" is removed
-    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 401
-    And the response header "Content-Type" is "application/json"
-    And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
-    And the response property "$.message" contains a user friendly text
-
-  @connected_network_type_subscriptions_retrieve_list_401.11_expired_access_token
-  Scenario: Expired access token when retrieving subscription list
-    Given the header "Authorization" is set to a previously valid but now expired access token
-    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
-    Then the response status code is 401
-    And the response header "Content-Type" is "application/json"
-    And the response property "$.status" is 401
-    And the response property "$.code" is "UNAUTHENTICATED"
-    And the response property "$.message" contains a user friendly text
-
-  @connected_network_type_subscriptions_retrieve_list_401.12_malformed_access_token
-  Scenario: Malformed access token when retrieving subscription list
-    Given the header "Authorization" is set to a malformed token
-    When the request "retrieveConnectedNetworkTypeSubscriptionList" is sent
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401


### PR DESCRIPTION
#### What type of PR is this?
* tests

#### What this PR does / why we need it:
Updates scenarios for retrieving device connected network type subscriptions to improve clarity and detail. Added pagination scenarios and refined existing scenarios for better compliance with OAS schema.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #79

#### Special notes for reviewers:
Tests copied from Commonalities template [here](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/event-subscription-template.feature)

#### Changelog input
```
 release-note
 - Update device connected network type subscription list scenarios
```

#### Additional documentation 
None